### PR TITLE
[bitnami/moodle] add option for custom storage class

### DIFF
--- a/bitnami/moodle/Chart.yaml
+++ b/bitnami/moodle/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: E-Learning
 apiVersion: v2
-appVersion: 3.11.2
+appVersion: 3.12.0
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/bitnami/moodle/README.md
+++ b/bitnami/moodle/README.md
@@ -109,6 +109,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `sessionAffinity`                    | Control where client requests go, to the same pod or round-robin                                                      | `None`                 |
 | `persistence.enabled`                | Enable persistence using PVC                                                                                          | `true`                 |
 | `persistence.storageClass`           | PVC Storage Class for Moodle                                                                                          | `""`                   |
+| `persistence.customStorageClass`     | Custom Storage Class for Moodle                                                                                          | `{}`                   |
 | `persistence.accessMode`             | PVC Access Mode for Moodle                                                                                            | `ReadWriteOnce`        |
 | `persistence.size`                   | PVC Storage Request for Moodle                                                                                        | `8Gi`                  |
 | `persistence.existingClaim`          | An Existing PVC name                                                                                                  | `""`                   |

--- a/bitnami/moodle/templates/storageclass.yaml
+++ b/bitnami/moodle/templates/storageclass.yaml
@@ -1,0 +1,7 @@
+{{- if and (.Values.persistence.enabled) (.Values.persistence.customStorageClass) -}}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ required ".Values.persistence.storageClass is required when using customStorageClass!" .Values.persistence.storageClass }}
+{{- toYaml .Values.persistence.customStorageClass | nindent 0 }}
+{{- end -}}

--- a/bitnami/moodle/values.yaml
+++ b/bitnami/moodle/values.yaml
@@ -170,6 +170,20 @@ persistence:
   ## @param persistence.enabled Enable persistence using PVC
   ##
   enabled: true
+  ## @param persistence.customStorageClass Create a custom storage class
+  ## Requires persistence.enabled: true
+  ## Requires persistence.storageClass: name
+  ## ref: https://kubernetes.io/docs/concepts/storage/storage-classes/
+  ## E.g.
+  ## provisioner: efs.csi.aws.com
+  ##   parameters:
+  ##     provisioningMode: efs-ap
+  ##     fileSystemId: fs-12345678
+  ##     directoryPerms: "700"
+  ##     gidRangeStart: "1000" # optional
+  ##     gidRangeEnd: "2000" # optional
+  ##
+  customStorageClass: {}
   ## @param persistence.storageClass PVC Storage Class for Moodle
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning
@@ -180,7 +194,8 @@ persistence:
   storageClass: ""
   ## @param persistence.accessMode PVC Access Mode for Moodle
   ## Requires persistence.enabled: true
-  ## If defined, PVC must be created manually before volume will be bound
+  ## If defined, and no customStorageClass is defined, then
+  ## PVC must be created manually before volume will be bound
   ##
   accessMode: ReadWriteOnce
   ## @param persistence.size PVC Storage Request for Moodle


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

This adds a new parameter `persistence.customStorageClass` to optionally create a custom storage class with the moodle release.  It uses the existing `persistence.storageClass` parameter as the name because that's used by the common chart to set the storage class within the PVC, and these values should match.

**Benefits**

<!-- What benefits will be realized by the code change? -->

This is useful when using the [aws-efs-csi-driver](https://github.com/kubernetes-sigs/aws-efs-csi-driver).  To connect the EFS volume to the PVC it requires a storage class.  

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

This is adding a new kubernetes resource to the chart but doesn't effect any existing resources or the default deployment.  I also only tested this with the EFS provisioner.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

Tested this with the following persistence settings in a values.yaml:
```
persistence:
  enabled: true
  storageClass: "efs-storage-test"

  customStorageClass:
    provisioner: efs.csi.aws.com
    parameters:
      provisioningMode: efs-ap
      fileSystemId: fs-xxxxxxxx
      directoryPerms: "777"
      gidRangeStart: "100" # optional
      gidRangeEnd: "2000" # optional
      basePath: "/dev"
```

The efs-csi-driver was able to create a PV and the directory for `/dev` and mounted to the moodle pod as expected.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
